### PR TITLE
Lock to version 3.2

### DIFF
--- a/activerecord-futures.gemspec
+++ b/activerecord-futures.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'activerecord', '~> 3.2.11'
-  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec', '2.13.0'
   gem.add_development_dependency 'rspec-spies'
   gem.add_development_dependency 'mysql2', '>= 0.3.12.b1'
   gem.add_development_dependency 'pg'

--- a/activerecord-futures.gemspec
+++ b/activerecord-futures.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'activerecord', '>= 3.2.11'
+  gem.add_dependency 'activerecord', '~> 3.2.11'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-spies'
   gem.add_development_dependency 'mysql2', '>= 0.3.12.b1'


### PR DESCRIPTION
ActiveRecord Futures doesn't work ActiveRecord 4, so the dependency should be tied to version 3.2.
